### PR TITLE
Compatibility with Capybara 2.x.

### DIFF
--- a/kelp.gemspec
+++ b/kelp.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/wapcaplet/kelp"
   s.platform = Gem::Platform::RUBY
 
-  s.add_dependency 'capybara', '~> 2.0.1'
+  s.add_dependency 'capybara', '~> 2.0'
 
   s.add_development_dependency 'sinatra'
   s.add_development_dependency 'rspec', '>= 2.2.0'

--- a/lib/kelp/visibility.rb
+++ b/lib/kelp/visibility.rb
@@ -189,7 +189,7 @@ module Kelp
     #
     def should_not_see_button(button_text, scope={})
       in_scope(scope) do
-        xpath = XPath::HTML.button(button_text)
+        xpath = XPath::HTML.button(button_text)[~ XPath.attr(:disabled)]
         if page.has_xpath?(xpath)
           raise Kelp::Unexpected, "Did not expect to see button '#{button_text}', but button exists."
         end


### PR DESCRIPTION
It looks like, with a minor change to explicitly look for "not disabled" inputs, the latest code is compatible with Capybara 2.0-2.4. Tests passed on 2.0.2, 2.1.0, 2.2.1, 2.3.0, and 2.4.1.
